### PR TITLE
User semver.compare to make sure latest version is detected correctly

### DIFF
--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -5,7 +5,8 @@ var Download = require('./download'),
     fs = require('graceful-fs'),
     maybeMkdir = require('./maybemkdir'),
     path = require('path'),
-    url = require('url');
+    url = require('url'),
+    semver = require('semver');
 
 
 /**
@@ -305,7 +306,7 @@ SyncManager.prototype = {
           copy.versions[version] = copyVersion;
         }.bind(this));
 
-        var sorted = versions.sort();
+        var sorted = versions.sort(semver.compare);
         var latestVersion = sorted[sorted.length - 1];
         copy['dist-tags'] = {
           'latest': latestVersion


### PR DESCRIPTION
1.16 should be later than 1.8.

I had the issue that mocha 1.8.2 was selected as the latest version while 1.16.2 was mirrored as well.
