### PR TITLE
Clone the packages.json file per package

### DIFF
--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -382,7 +382,8 @@ SyncManager.prototype = {
         var packageVersion = JSON.parse(packageVersionData);
         var copy = JSON.parse(packageVersionData);
         if ('dist' in copy) {
-          copy.dist.tarball = Package.tarballUrl(this.hostname, package, version)
+          copy.dist.tarball =
+            Package.tarballUrl(this.hostname, package, version);
         }
 
         var dest = path.resolve(this.tempdir, package, version, 'index.json');

--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -287,19 +287,9 @@ SyncManager.prototype = {
         var versions = Object.keys(this.packageToVersions[package]);
         versions.forEach(function(version) {
           var packageRootVersion = packageRoot.versions[version];
-          var copyVersion = {
-            name: packageRoot.name,
-            version: version,
-            description: packageRoot.description || '',
-            dependencies: packageRootVersion.dependencies || {},
-            devDependencies: packageRootVersion.devDependencies || {},
-            peerDependencies: packageRootVersion.peerDependencies || {}
-          };
+          var copyVersion = JSON.parse(JSON.stringify(packageRootVersion));
           if ('dist' in packageRootVersion) {
-            copyVersion.dist = {
-              shasum: packageRootVersion.dist.shasum,
-              tarball: Package.tarballUrl(this.hostname, package, version)
-            };
+            copyVersion.dist.tarball = Package.tarballUrl(this.hostname, package, version);
           }
           copy.versions[version] = copyVersion;
         }.bind(this));

--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -290,6 +290,7 @@ SyncManager.prototype = {
           var copyVersion = {
             name: packageRoot.name,
             version: version,
+            description: packageRoot.description || '',
             dependencies: packageRootVersion.dependencies || {},
             devDependencies: packageRootVersion.devDependencies || {},
             peerDependencies: packageRootVersion.peerDependencies || {}
@@ -379,18 +380,9 @@ SyncManager.prototype = {
       // Copy it to our mirror.
       function(packageVersionData, done) {
         var packageVersion = JSON.parse(packageVersionData);
-        var copy = {
-          name: packageVersion.name,
-          version: packageVersion.version,
-          dependencies: packageVersion.dependencies || {},
-          devDependencies: packageVersion.devDependencies || {},
-          peerDependencies: packageVersion.peerDependencies || {}
-        };
-        if ('dist' in packageVersion) {
-          copy.dist = {
-            shasum: packageVersion.dist.shasum,
-            tarball: Package.tarballUrl(this.hostname, package, version)
-          };
+        var copy = JSON.parse(packageVersionData);
+        if ('dist' in copy) {
+          copy.dist.tarball = Package.tarballUrl(this.hostname, package, version)
         }
 
         var dest = path.resolve(this.tempdir, package, version, 'index.json');


### PR DESCRIPTION
Previously this was missing vital attributes like 'main', which causes CommonJS module resolution using require() to fail.

This currently renders npm-mirror unusable for me, as packages only work once installed if their dependencies are specified as relative paths rather than CommonJS modules.

This makes me wonder if the behaviour of npm install has changed recently regarding how the `package.json` file in your local node_modules directory gets created. It seems to be decompressing the tgz and then overwriting the `package.json` file in that with the top-level `index.json` equivalent off the registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-b2g/npm-mirror/25)
<!-- Reviewable:end -->
