### PR TITLE
Simple patch to mirror more package metadata, such as "main".

### DIFF
--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -9,8 +9,8 @@ var Download = require('./download'),
     path = require('path'),
     semver = require('semver'),
     sha = require('sha'),
-    url = require('url');
-
+    url = require('url'),
+    extend = require('util')._extend;
 
 /**
  * @constructor
@@ -287,13 +287,13 @@ SyncManager.prototype = {
         var versions = Object.keys(this.packageToVersions[package]);
         versions.forEach(function(version) {
           var packageRootVersion = packageRoot.versions[version];
-          var copyVersion = {
+          copyVersion = extend(extend({}, packageRootVersion), {
             name: packageRoot.name,
             version: version,
             dependencies: packageRootVersion.dependencies || {},
             devDependencies: packageRootVersion.devDependencies || {},
             peerDependencies: packageRootVersion.peerDependencies || {}
-          };
+          });
           if ('dist' in packageRootVersion) {
             copyVersion.dist = {
               shasum: packageRootVersion.dist.shasum,

--- a/lib/syncmanager.js
+++ b/lib/syncmanager.js
@@ -287,7 +287,7 @@ SyncManager.prototype = {
         var versions = Object.keys(this.packageToVersions[package]);
         versions.forEach(function(version) {
           var packageRootVersion = packageRoot.versions[version];
-          copyVersion = extend(extend({}, packageRootVersion), {
+          var copyVersion = extend(extend({}, packageRootVersion), {
             name: packageRoot.name,
             version: version,
             dependencies: packageRootVersion.dependencies || {},


### PR DESCRIPTION
Currently, npm-mirror doesn't mirror enough package metadata for newer modules.  For example, the "clone" module has no index.js and relies on the "main" attribute to help Node load the right file. Without that metadata, installation from a mirror fails in ugly, hard-to-debug ways. This patch makes npm-mirror copy the rest of the package metadata into the mirror.
